### PR TITLE
Install rakuten web service rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /log/*
 !/log/.keep
 /tmp
+
+/config/rakuten_web_service.yml

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development do
   gem 'spring'
 end
 
-gem 'rakuten_web_service'
+gem 'rakuten_web_service-rails', '~> 0.3.0'
 gem 'pg'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.4.2)
-    rakuten_web_service (1.3.0)
+    rakuten_web_service (1.4.1)
+    rakuten_web_service-rails (0.3.0)
+      rails (> 4.2, < 5.1.0)
+      rakuten_web_service (~> 1.4.0)
     rdoc (4.2.0)
     rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
@@ -188,7 +191,7 @@ DEPENDENCIES
   pg
   rails (= 4.2.5)
   rails_12factor
-  rakuten_web_service
+  rakuten_web_service-rails (~> 0.3.0)
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,20 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: rws_ruby_sdk_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: rws_ruby_sdk_test
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/rakuten_web_service.yml.sample
+++ b/config/rakuten_web_service.yml.sample
@@ -1,0 +1,11 @@
+development:
+  application_id: DEV_APPLICATION_ID
+  affiliate_id: DEV_AFFILIATE_ID
+
+test:
+  application_id: TEST_APPLICATION_ID
+  affiliate_id: TEST_AFFILIATE_ID
+
+production:
+  application_id: <%= ENV['RWS_APPLICATION_ID'] %>
+  affiliate_id: <%= ENV['RWS_AFFILIATE_ID'] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,4 +13,7 @@
 
 ActiveRecord::Schema.define(version: 0) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
 end


### PR DESCRIPTION
`rakuten_web_service-rails` has been released. From this version, the gem provides the generator to generate a template of the  configuration file for `rakuten_web_service` in YAML and also provides an initialize to load the configuration file and/or loads the configuration from environment variables, `RWS_APPLICATION_ID` and `RWS_AFFILIATE_ID`.  

The PR has updates so that this application uses the gem to load configurations for `rakuten_web_service` from `config/rakuten_web_service.yml` in development and test, and the environment variables in production environment. 
